### PR TITLE
refs #000: Bump default composer version to 2.8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: shellcheck
 
-COMPOSER_VERSION ?= 2.5.4
+COMPOSER_VERSION ?= 2.8.1
 
 # build-7-1-11: build-test-image
 # 	docker buildx build --load -t sparkfabrik/docker-php-base-image:7.1.11-fpm-alpine3.4 7.1.11-fpm-alpine3.4


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgraded the default Composer version from 2.5.4 to 2.8.1 in the Makefile
- This update ensures the project uses a more recent version of Composer, potentially bringing improvements and bug fixes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Update default Composer version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

- Updated the default Composer version from 2.5.4 to 2.8.1



</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-php-base-image/pull/78/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

