### PR TITLE
feat(php8): add PHP 8.5.7 and refresh image dependencies

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,26 +7,30 @@ on:
 
 env:
   IMAGE_NAME: docker-php-base-image
-  COMPOSER_VERSION: 2.9.6
+  COMPOSER_VERSION: 2.10.1
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tag: [8-4-22, 8-4-2, 8-3-15, 8-3-2, 8-2-3, 8-1-16, 8-1-10]
+        tag: [8-5-7, 8-4-22, 8-4-2, 8-3-15, 8-3-2, 8-2-3, 8-1-16, 8-1-10]
         flavour: ["", "-rootless"]
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
+      # The test job builds a single native (amd64) image with --load, so it
+      # does not need QEMU. Skipping it avoids the parallel binfmt cache race
+      # and speeds up the job setup.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Build and test the image
-        run: make build-${{ matrix.tag }}${{ matrix.flavour }}
+        env:
+          SCOPE: ${{ matrix.tag }}${{ matrix.flavour }}
+        run: |
+          make build-${{ matrix.tag }}${{ matrix.flavour }} \
+            BUILDX_CACHE="--cache-from type=gha,scope=${SCOPE} --cache-to type=gha,mode=max,scope=${SCOPE}"
 
   deploy:
     needs: test
@@ -36,6 +40,7 @@ jobs:
       matrix:
         tag:
           [
+            8.5.7-fpm-alpine3.24,
             8.4.22-fpm-alpine3.24,
             8.4.2-fpm-alpine3.21,
             8.3.15-fpm-alpine3.21,
@@ -88,8 +93,9 @@ jobs:
           # Change all uppercase to lowercase.
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           echo IMAGE_ID=$IMAGE_ID
-          docker buildx build --push $BASE_FOLDER --platform "linux/amd64,linux/arm64" --build-arg PHPVER=${{ matrix.tag }} --tag $IMAGE_ID:${{ matrix.tag }} --target dist
-          docker buildx build --push $BASE_FOLDER --platform "linux/amd64,linux/arm64" --build-arg PHPVER=${{ matrix.tag }} --tag $IMAGE_ID:${{ matrix.tag }}-dev --target dev --build-arg COMPOSER_VERSION="${COMPOSER_VERSION}"
+          SCOPE="${{ matrix.tag }}${{ matrix.flavour }}"
+          docker buildx build --push $BASE_FOLDER --platform "linux/amd64,linux/arm64" --build-arg PHPVER=${{ matrix.tag }} --tag $IMAGE_ID:${{ matrix.tag }} --target dist --cache-from type=gha,scope=${SCOPE} --cache-to type=gha,mode=max,scope=${SCOPE}
+          docker buildx build --push $BASE_FOLDER --platform "linux/amd64,linux/arm64" --build-arg PHPVER=${{ matrix.tag }} --tag $IMAGE_ID:${{ matrix.tag }}-dev --target dev --build-arg COMPOSER_VERSION="${COMPOSER_VERSION}" --cache-from type=gha,scope=${SCOPE} --cache-to type=gha,mode=max,scope=${SCOPE}
 
       - name: Build and push images to GitHub Container Registry (rootless)
         if: ${{ matrix.flavour == '-rootless' }}
@@ -106,5 +112,6 @@ jobs:
           # Change all uppercase to lowercase.
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           echo IMAGE_ID=$IMAGE_ID
-          docker buildx build --push $BASE_FOLDER --platform "linux/amd64,linux/arm64" --build-arg PHPVER=${{ matrix.tag }} --build-arg user=1001 --tag $IMAGE_ID:${{ matrix.tag }}-rootless --target dist
-          docker buildx build --push $BASE_FOLDER --platform "linux/amd64,linux/arm64" --build-arg PHPVER=${{ matrix.tag }} --build-arg user=1001 --tag $IMAGE_ID:${{ matrix.tag }}-rootless-dev --target dev --build-arg COMPOSER_VERSION="${COMPOSER_VERSION}"
+          SCOPE="${{ matrix.tag }}${{ matrix.flavour }}"
+          docker buildx build --push $BASE_FOLDER --platform "linux/amd64,linux/arm64" --build-arg PHPVER=${{ matrix.tag }} --build-arg user=1001 --tag $IMAGE_ID:${{ matrix.tag }}-rootless --target dist --cache-from type=gha,scope=${SCOPE} --cache-to type=gha,mode=max,scope=${SCOPE}
+          docker buildx build --push $BASE_FOLDER --platform "linux/amd64,linux/arm64" --build-arg PHPVER=${{ matrix.tag }} --build-arg user=1001 --tag $IMAGE_ID:${{ matrix.tag }}-rootless-dev --target dev --build-arg COMPOSER_VERSION="${COMPOSER_VERSION}" --cache-from type=gha,scope=${SCOPE} --cache-to type=gha,mode=max,scope=${SCOPE}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tag: [8-5-7, 8-4-22, 8-4-2, 8-3-15, 8-3-2, 8-2-3, 8-1-16, 8-1-10]
+        tag: [8-5-7, 8-4-22, 8-4-2, 8-3-15, 8-3-2]
         flavour: ["", "-rootless"]
     steps:
       - uses: actions/checkout@v6
@@ -45,9 +45,6 @@ jobs:
             8.4.2-fpm-alpine3.21,
             8.3.15-fpm-alpine3.21,
             8.3.2-fpm-alpine3.18,
-            8.2.3-fpm-alpine3.16,
-            8.1.16-fpm-alpine3.16,
-            8.1.10-fpm-alpine3.16,
           ]
         flavour: ["", "-rootless"]
     steps:

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -1,6 +1,6 @@
-ARG PHPVER
+ARG PHPVER=8.5.7-fpm-alpine3.24
 
-FROM golang:1.26-alpine3.23 as mailhog
+FROM golang:1.26-alpine3.24 AS mailhog
 
 # Install mailhog.
 ENV MAILHOG_VERSION=1.0.1
@@ -8,7 +8,7 @@ RUN apk add git && \
     go install github.com/mailhog/MailHog@v${MAILHOG_VERSION} && \
     mv /go/bin/MailHog /go/mailhog
 
-FROM php:$PHPVER as dist
+FROM php:$PHPVER AS dist
 
 # Build target arch passed by BuildKit
 ARG TARGETARCH
@@ -23,8 +23,8 @@ ENV PHP_REALPATH_CACHE_SIZE=2M
 ENV PHP_UPLOAD_MAX_FILE_SIZE=32M
 ENV PHP_POST_MAX_SIZE=32M
 ENV PHP_MAX_EXECUTION_TIME=30
-ENV BLACKFIRE_HOST=${BLACKFIRE_HOST:-blackfire}
-ENV BLACKFIRE_PORT=${BLACKFIRE_PORT:-8307}
+ENV BLACKFIRE_HOST=blackfire
+ENV BLACKFIRE_PORT=8307
 ENV PHP_EXPOSE_PHP=0
 
 # FPM Configurations.
@@ -35,9 +35,9 @@ ENV PHP_FPM_MIN_SPARE_SERVERS=1
 ENV PHP_FPM_MAX_SPARE_SERVERS=3
 ENV PHP_FPM_PM_STATUS_PATH=/status
 
-ENV XDEBUG_VERSION=3.4.1
-ENV MEMCACHE_VERSION=3.3.0
-ENV PHPREDIS_VERSION=6.1.0
+ENV XDEBUG_VERSION=3.5.3
+ENV MEMCACHE_VERSION=3.4.0
+ENV PHPREDIS_VERSION=6.3.0
 RUN export XDEBUG_DEPS="linux-headers" && \
     export PHP_EXTRA_DEPS="libxml2-dev icu-dev libmemcached-dev cyrus-sasl-dev libpng libjpeg-turbo freetype-dev libpng-dev libjpeg-turbo-dev libzip-dev oniguruma-dev libwebp-dev libldap openldap-dev openssl-dev" && \
     apk update && \
@@ -53,13 +53,13 @@ RUN export XDEBUG_DEPS="linux-headers" && \
     rm -rf /var/cache/apk/*
 
 # Install APCu.
-ENV APCU_VERSION=5.1.24
+ENV APCU_VERSION=5.1.28
 RUN apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS && \
     pecl install apcu-${APCU_VERSION} && \
     apk del .phpize-deps-configure
 
 # Install blackfire client.
-ENV BLACKFIRE_CLIENT_VERSION=2.8.1
+ENV BLACKFIRE_CLIENT_VERSION=2026.6.0
 RUN mkdir -p /tmp/blackfire && \
     curl -A "Docker" -L https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_CLIENT_VERSION}/blackfire-linux_${TARGETARCH}.tar.gz | tar zxp -C /tmp/blackfire && \
     mv /tmp/blackfire/blackfire /usr/bin/blackfire && \
@@ -88,6 +88,13 @@ COPY conf/*.ini /usr/local/etc/php/conf.d/
 COPY conf.disabled /usr/local/etc/php/conf.disabled
 COPY fpm-conf-templates/ /templates/
 
+# Load OPcache as a Zend extension only when it ships as a shared object
+# (PHP <= 8.4). Since PHP 8.5 OPcache is statically compiled into the binary,
+# so loading opcache.so would fail; opcache.ini still tunes it in both cases.
+RUN if [ -f "$(php -r 'echo ini_get("extension_dir");')/opcache.so" ]; then \
+        echo "zend_extension=opcache.so" > /usr/local/etc/php/conf.d/00-opcache-load.ini; \
+    fi
+
 # Make folders writable for the root group
 RUN chmod 775 /usr/local/etc/php && \
     chmod 775 /usr/local/etc/php/conf.d && \
@@ -100,7 +107,7 @@ USER $user
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 CMD ["php-fpm"]
 
-FROM dist as dev
+FROM dist AS dev
 
 # Build target arch passed by BuildKit
 ARG TARGETARCH

--- a/8/conf/opcache.ini
+++ b/8/conf/opcache.ini
@@ -1,4 +1,3 @@
-zend_extension=opcache.so
 opcache.enable=${PHP_OPCACHE_ENABLE}
 opcache.enable_cli=0
 opcache.memory_consumption=${PHP_OPCACHE_MEMORY}

--- a/Makefile
+++ b/Makefile
@@ -138,23 +138,25 @@ BUILDX_CACHE ?=
 # build-8-1-12-rootless: PHPVER=8.1.12-fpm-alpine3.16
 # build-8-1-12-rootless: build-rootless-template
 
-build-8-1-10: PHPVER=8.1.10-fpm-alpine3.16
-build-8-1-10: build-template
+# PHP 8.1 reached end of life on 2025-12-31; targets kept commented for reference.
+# build-8-1-10: PHPVER=8.1.10-fpm-alpine3.16
+# build-8-1-10: build-template
+#
+# build-8-1-10-rootless: PHPVER=8.1.10-fpm-alpine3.16
+# build-8-1-10-rootless: build-rootless-template
+#
+# build-8-1-16: PHPVER=8.1.16-fpm-alpine3.16
+# build-8-1-16: build-template
+#
+# build-8-1-16-rootless: PHPVER=8.1.16-fpm-alpine3.16
+# build-8-1-16-rootless: build-rootless-template
 
-build-8-1-10-rootless: PHPVER=8.1.10-fpm-alpine3.16
-build-8-1-10-rootless: build-rootless-template
-
-build-8-1-16: PHPVER=8.1.16-fpm-alpine3.16
-build-8-1-16: build-template
-
-build-8-1-16-rootless: PHPVER=8.1.16-fpm-alpine3.16
-build-8-1-16-rootless: build-rootless-template
-
-build-8-2-3: PHPVER=8.2.3-fpm-alpine3.16
-build-8-2-3: build-template
-
-build-8-2-3-rootless: PHPVER=8.2.3-fpm-alpine3.16
-build-8-2-3-rootless: build-rootless-template
+# PHP 8.2 images retired; targets kept commented for reference.
+# build-8-2-3: PHPVER=8.2.3-fpm-alpine3.16
+# build-8-2-3: build-template
+#
+# build-8-2-3-rootless: PHPVER=8.2.3-fpm-alpine3.16
+# build-8-2-3-rootless: build-rootless-template
 
 build-8-3-2: PHPVER=8.3.2-fpm-alpine3.18
 build-8-3-2: build-template

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: shellcheck
 
-COMPOSER_VERSION = 2.8.9
+COMPOSER_VERSION = 2.10.1
+
+# Optional extra buildx flags (e.g. layer caching). Empty by default so local
+# `make` builds work without a cache backend; CI passes --cache-from/--cache-to.
+BUILDX_CACHE ?=
 
 # build-7-1-11: build-test-image
 # 	docker buildx build --load -t sparkfabrik/docker-php-base-image:7.1.11-fpm-alpine3.4 7.1.11-fpm-alpine3.4
@@ -176,6 +180,12 @@ build-8-4-22: build-template
 build-8-4-22-rootless: PHPVER=8.4.22-fpm-alpine3.24
 build-8-4-22-rootless: build-rootless-template
 
+build-8-5-7: PHPVER=8.5.7-fpm-alpine3.24
+build-8-5-7: build-template
+
+build-8-5-7-rootless: PHPVER=8.5.7-fpm-alpine3.24
+build-8-5-7-rootless: build-rootless-template
+
 build-template: guessing-folder build-test-image
 	docker buildx build \
 		--load \
@@ -183,6 +193,7 @@ build-template: guessing-folder build-test-image
 		--target dist \
 		-t sparkfabrik/docker-php-base-image:$(PHPVER) \
 		--progress=$${DOCKER_BUILD_PROGRESS:-auto} \
+		$(BUILDX_CACHE) \
 		$(shell ./scripts/guess_folder.sh "$(PHPVER)")
 	docker buildx build \
 		--load \
@@ -191,6 +202,7 @@ build-template: guessing-folder build-test-image
 		--target dev \
 		-t sparkfabrik/docker-php-base-image:$(PHPVER)-dev \
 		--progress=$${DOCKER_BUILD_PROGRESS:-auto} \
+		$(BUILDX_CACHE) \
 		$(shell ./scripts/guess_folder.sh "$(PHPVER)")
 	./tests/tests_wrapper.sh php7 sparkfabrik/docker-php-base-image:$(PHPVER) root
 
@@ -202,6 +214,7 @@ build-rootless-template: guessing-folder build-test-image
 		--target dist \
 		-t sparkfabrik/docker-php-base-image:$(PHPVER)-rootless \
 		--progress=$${DOCKER_BUILD_PROGRESS:-auto} \
+		$(BUILDX_CACHE) \
 		$(shell ./scripts/guess_folder.sh "$(PHPVER)")
 	docker buildx build \
 		--load \
@@ -211,6 +224,7 @@ build-rootless-template: guessing-folder build-test-image
 		--target dev \
 		-t sparkfabrik/docker-php-base-image:$(PHPVER)-rootless-dev \
 		--progress=$${DOCKER_BUILD_PROGRESS:-auto} \
+		$(BUILDX_CACHE) \
 		$(shell ./scripts/guess_folder.sh "$(PHPVER)")
 	./tests/tests_wrapper.sh php7 sparkfabrik/docker-php-base-image:$(PHPVER)-rootless "unknown uid 1001"
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 - XDEBUG 3.5.3
 - MAILHOG v1.0.1
-- BLACKFIRE (client 2.8.1, probe latest)
+- BLACKFIRE (client 2026.6.0, probe latest)
 
 ## Env variables
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Docker PHP base images
 
-[![](https://images.microbadger.com/badges/image/sparkfabrik/docker-php-base-image.svg)](https://microbadger.com/images/sparkfabrik/docker-php-base-image "Get your own image badge on microbadger.com")
-
 ## Packages
 
 ### PHP Modules

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # Docker PHP base images
 
-[![](https://images.microbadger.com/badges/image/sparkfabrik/docker-php-base-image.svg)](https://microbadger.com/images/sparkfabrik/docker-php-base-image 'Get your own image badge on microbadger.com')
+[![](https://images.microbadger.com/badges/image/sparkfabrik/docker-php-base-image.svg)](https://microbadger.com/images/sparkfabrik/docker-php-base-image "Get your own image badge on microbadger.com")
 
 ## Packages
 
 ### PHP Modules
 
+- apcu
 - bcmath
+- ftp
 - gd
+- igbinary
 - intl
+- ldap (not activated by default)
 - mbstring
 - memcached (not activated by default)
 - pcntl
@@ -21,9 +25,9 @@
 
 ### Tools
 
-- XDEBUG 2.9.0
-- MAILHOG v0.1.9
-- BLACKFIRE (latest)
+- XDEBUG 3.5.3
+- MAILHOG v1.0.1
+- BLACKFIRE (client 2.8.1, probe latest)
 
 ## Env variables
 


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @Monska85._

## Summary

Adds PHP 8.5.7 to the shared 8.x image, refreshes the pinned dependencies, retires the end-of-life PHP 8.1 and 8.2 images, and speeds up CI. The build, the full end-to-end test suite, and a backward-compatibility build of PHP 8.1.10 were all run locally and pass.

After this change the CI builds and publishes `8.3.2`, `8.3.15`, `8.4.2`, `8.4.22`, and `8.5.7` (each with a `-rootless` flavour).

## PHP 8.5 support

PHP 8.5.7 (`alpine3.24`) is added to the Makefile build targets and to both the CI test and deploy matrices. The shared image needed several changes to build and run on 8.5:

- xdebug `3.4.1` → `3.5.3` (xdebug 3.4 does not support PHP 8.5; 3.5 still covers 8.1–8.4)
- phpredis `6.1.0` → `6.3.0` (6.1 fails to compile against the PHP 8.5 headers: `php_smart_string.h: No such file`)
- memcached `3.3.0` → `3.4.0`, apcu `5.1.24` → `5.1.28`
- OPcache is statically compiled into the PHP 8.5 binary and no longer ships as `opcache.so`. The hardcoded `zend_extension=opcache.so` is removed from `opcache.ini` and loaded conditionally only when the shared object exists, so PHP 8.1–8.4 behaviour is unchanged.

## Retire end-of-life images

PHP 8.1 reached end of life on 2025-12-31. The 8.1 and 8.2 images are removed from the CI test and deploy matrices so they are no longer built or published. The 8.3, 8.4 and 8.5 images remain active. The Makefile targets for the retired versions are kept, commented out, for reference and easy reinstatement.

## Dependency refresh

- golang builder `1.26-alpine3.23` → `1.26-alpine3.24` (matches the PHP base alpine)
- blackfire client `2.8.1` → `2026.6.0`
- composer aligned to `2.10.1` (was `2.8.9` in the Makefile and `2.9.6` in CI)

MailHog stays at `1.0.1` (upstream repository is archived).

## BuildKit check fixes

Resolves the build-check warnings emitted by buildx:

- `FromAsCasing`: `FROM ... as` → `FROM ... AS`
- `InvalidDefaultArgInFrom`: `ARG PHPVER` given a default
- `UndefinedVar`: `BLACKFIRE_HOST`/`BLACKFIRE_PORT` assigned directly instead of self-referencing undefined variables

## CI speedups

- The test job no longer sets up QEMU. It builds a single native amd64 image with `--load`, so QEMU was unused; removing it also drops most of the parallel `tonistiigi/binfmt` cache-reservation warnings.
- The test and deploy jobs now use a GitHub Actions layer cache (`type=gha`, `mode=max`) scoped per tag and flavour, so unchanged versions reuse cached layers instead of recompiling every extension. A new optional `BUILDX_CACHE` make variable threads the cache flags through and defaults to empty, leaving local builds unaffected.

## Docs

- README module list updated (apcu, ftp, igbinary, ldap) and tool versions corrected (xdebug 3.5.3, mailhog 1.0.1, blackfire client 2026.6.0).
- Removed the dead MicroBadger badge (the service was retired by Docker in 2020 and the badge no longer renders).

## Follow-up

Native arm64 runners (`ubuntu-24.04-arm`) for the deploy job, to remove QEMU emulation of the arm64 build, will be implemented in a follow-up.