### PR TITLE
fix(ci): stop rootless and non-rootless tags resolving to the same image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -140,7 +140,10 @@ jobs:
       - name: Upload digests
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.tag.full }}${{ matrix.flavour }}-${{ matrix.platform.arch }}
+          # Use a non-empty flavour label ("default"/"rootless") so the
+          # non-rootless artifact name is not a prefix of the rootless one;
+          # otherwise the merge download glob would match both flavours.
+          name: digests-${{ matrix.tag.full }}-${{ matrix.flavour == '-rootless' && 'rootless' || 'default' }}-${{ matrix.platform.arch }}
           path: digests/*
           if-no-files-found: error
           retention-days: 1
@@ -171,7 +174,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: digests
-          pattern: digests-${{ matrix.tag.full }}${{ matrix.flavour }}-*
+          pattern: digests-${{ matrix.tag.full }}-${{ matrix.flavour == '-rootless' && 'rootless' || 'default' }}-*
           merge-multiple: true
 
       - name: Create and push multi-arch manifests


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @Monska85._

## Problem

After the native-build workflow landed, the published `:<tag>` and `:<tag>-rootless` images resolve to the **same** image.

## Root cause

The `merge` job downloads the per-architecture digest artifacts with the pattern `digests-<tag><flavour>-*`. For the non-rootless flavour the `<flavour>` segment is empty, so the pattern becomes `digests-<tag>-*`, which also matches the rootless artifacts (`digests-<tag>-rootless-<arch>`).

The digest files inside each artifact are named only by architecture (`dist-amd64`, `dev-arm64`, …), with no flavour in the filename. With `merge-multiple: true`, the rootless files then overwrite the non-rootless files of the same name, so the non-rootless `:<tag>` manifest is assembled from the rootless digests.

The rootless merge was unaffected because `digests-<tag>-rootless-*` matches only rootless artifacts.

## Fix

Name the digest artifacts with a non-empty flavour label, `default` or `rootless`, so the non-rootless artifact name is no longer a prefix of the rootless one. The merge job downloads each flavour with its matching, non-overlapping pattern:

- non-rootless: `digests-<tag>-default-*`
- rootless: `digests-<tag>-rootless-*`

The image tags themselves are unchanged (`:<tag>`, `:<tag>-rootless`, and the `-dev` variants); only the intermediate artifact naming changes.

## Validation

`actionlint` reports no workflow errors (only the pre-existing info-level shellcheck notes). The build and merge jobs run only on `master`, so the fix is first exercised by the merge commit; the resulting manifests should be spot-checked with `docker buildx imagetools inspect` to confirm the two flavours now differ.