### PR TITLE
fix(php8): prevent OPcache double-load without disabling it on older parents

### DIFF
--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -88,6 +88,16 @@ COPY conf/*.ini /usr/local/etc/php/conf.d/
 COPY conf.disabled /usr/local/etc/php/conf.disabled
 COPY fpm-conf-templates/ /templates/
 
+# Enable OPcache as a Zend extension only when the parent image hasn't already
+# (older php:8.x parents don't ship docker-php-ext-opcache.ini) and it ships as
+# a shared object. Newer parents (PHP 8.4.22+) and static builds (PHP 8.5)
+# already load it, so the guard avoids the "Cannot load Zend OPcache - it was
+# already loaded" double-load while keeping OPcache enabled everywhere.
+RUN if [ ! -f /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini ] \
+        && [ -f "$(php -r 'echo ini_get("extension_dir");')/opcache.so" ]; then \
+        echo "zend_extension=opcache.so" > /usr/local/etc/php/conf.d/00-opcache-load.ini; \
+    fi
+
 # Make folders writable for the root group
 RUN chmod 775 /usr/local/etc/php && \
     chmod 775 /usr/local/etc/php/conf.d && \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -88,13 +88,6 @@ COPY conf/*.ini /usr/local/etc/php/conf.d/
 COPY conf.disabled /usr/local/etc/php/conf.disabled
 COPY fpm-conf-templates/ /templates/
 
-# Load OPcache as a Zend extension only when it ships as a shared object
-# (PHP <= 8.4). Since PHP 8.5 OPcache is statically compiled into the binary,
-# so loading opcache.so would fail; opcache.ini still tunes it in both cases.
-RUN if [ -f "$(php -r 'echo ini_get("extension_dir");')/opcache.so" ]; then \
-        echo "zend_extension=opcache.so" > /usr/local/etc/php/conf.d/00-opcache-load.ini; \
-    fi
-
 # Make folders writable for the root group
 RUN chmod 775 /usr/local/etc/php && \
     chmod 775 /usr/local/etc/php/conf.d && \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -88,11 +88,12 @@ COPY conf/*.ini /usr/local/etc/php/conf.d/
 COPY conf.disabled /usr/local/etc/php/conf.disabled
 COPY fpm-conf-templates/ /templates/
 
-# Enable OPcache as a Zend extension only when the parent image hasn't already
-# (older php:8.x parents don't ship docker-php-ext-opcache.ini) and it ships as
-# a shared object. Newer parents (PHP 8.4.22+) and static builds (PHP 8.5)
-# already load it, so the guard avoids the "Cannot load Zend OPcache - it was
-# already loaded" double-load while keeping OPcache enabled everywhere.
+# Enable OPcache as a Zend extension only when the parent image has not already
+# done so. The official php image enables OPcache by default (ships
+# docker-php-ext-opcache.ini) since docker-library/php#1587; parents built
+# before that, and any without the shared opcache.so, still need the manual
+# loader. Keying off the ini file keeps OPcache enabled everywhere while
+# avoiding the "Cannot load Zend OPcache - it was already loaded" double-load.
 RUN if [ ! -f /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini ] \
         && [ -f "$(php -r 'echo ini_get("extension_dir");')/opcache.so" ]; then \
         echo "zend_extension=opcache.so" > /usr/local/etc/php/conf.d/00-opcache-load.ini; \

--- a/8/conf/opcache.ini
+++ b/8/conf/opcache.ini
@@ -4,5 +4,4 @@ opcache.memory_consumption=${PHP_OPCACHE_MEMORY}
 opcache.interned_strings_buffer=8
 opcache.max_accelerated_files=100000
 opcache.use_cwd=1
-opcache.fast_shutdown=1
 opcache.revalidate_freq=0


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @lussoluca._

## Problem

Since `e9b6e49` ("feat(php8): add PHP 8.5.7 and refresh image dependencies"), the 8.x image emits at every PHP invocation on some builds:

```
Cannot load Zend OPcache - it was already loaded
```

Reproduced on the `8.4.22-fpm-alpine3.24-rootless` tag. The `8.4.2` tag (built before that commit) is clean.

## Root cause

Commit `e9b6e49` added a loader block:

```dockerfile
RUN if [ -f "$(php -r 'echo ini_get("extension_dir");')/opcache.so" ]; then \ echo "zend_extension=opcache.so" > /usr/local/etc/php/conf.d/00-opcache-load.ini; \ fi
```

This fires whenever `opcache.so` exists (all PHP <= 8.4). Whether that double-loads depends on whether the official `php` parent **already** enables OPcache.

The official image started enabling OPcache by default in [docker-library/php#1587 "Enable opcache by default"](https://github.com/docker-library/php/pull/1587), **merged 2025-06-25**, which adds `RUN docker-php-ext-enable opcache` to every Dockerfile variant (motivated by the RFC [make_opcache_required](https://wiki.php.net/rfc/make_opcache_required)). The determining factor is whether a given `php:<patch>` tag was **built after that merge** — not the Alpine version. Pinned old patch releases keep their pre-merge frozen image; newer patches were rebuilt with the change.

So:

- **Parent built post-merge** (e.g. `php:8.4.22-fpm-alpine3.24`) — already loads OPcache via `docker-php-ext-opcache.ini`; our block adds a second loader → double-load warning.
- **Parent built pre-merge** (e.g. `php:8.3.2-fpm-alpine3.18`, `php:8.3.15-fpm-alpine3.21`, `php:8.4.2-fpm-alpine3.21`) — does NOT load OPcache; our block is the **only** loader.
- **PHP 8.5** — OPcache is statically compiled, `opcache.so` is absent, the block never fires; parent loads it statically.

Verified against the official parents:

| official parent | ships `docker-php-ext-opcache.ini` | OPcache loaded by parent |
| --- | --- | --- |
| `php:8.3.2-fpm-alpine3.18` (pinned, pre-merge)  | no  | false |
| `php:8.3.15-fpm-alpine3.21` (pinned, pre-merge) | no  | false |
| `php:8.4.2-fpm-alpine3.21` (pinned, pre-merge)  | no  | false |
| `php:8.3-fpm-alpine3.21` (rolling, post-merge)  | yes | true  |
| `php:8.4.22-fpm-alpine3.24` (post-merge)        | yes | true  |
| `php:8.5.7-fpm-alpine3.24` (static)             | static | true |

The two alpine3.21 rows show the split is build-date, not Alpine version.

## Why not just delete the block

An earlier revision of this PR removed the block entirely. That regressed OPcache on every build whose parent predates docker-library/php#1587 (currently 8.3.2, 8.3.15, 8.4.2) — verified by building 8.3.15 from that revision: no loader present, `extension_loaded("Zend OPcache")` → `false`. The block was not "always redundant"; it was redundant only on post-merge parents.

## Fix

Guard the block so it adds `00-opcache-load.ini` only when the parent has **not** already enabled OPcache and `opcache.so` exists:

```dockerfile
RUN if [ ! -f /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini ] \
        && [ -f "$(php -r 'echo ini_get("extension_dir");')/opcache.so" ]; then \
        echo "zend_extension=opcache.so" > /usr/local/etc/php/conf.d/00-opcache-load.ini; \
    fi
```

This is version- and date-agnostic: it keys off the actual presence of the parent's opcache ini.

## Additional cleanup: drop dead `opcache.fast_shutdown`

`8/conf/opcache.ini` set `opcache.fast_shutdown=1`. That directive was removed in PHP 7.2 — fast shutdown became always-on and the option no longer exists. On PHP 8.x it is absent from `phpinfo()` and `ini_get("opcache.fast_shutdown")` returns `false`, so the line is silently ignored dead config. The `8/` image only targets PHP 8.x, so it can never apply. Removed.

## Verification

Built from this branch (`--build-arg PHPVER=...`, `--target dist`) and checked OPcache state:

| version | loader source | `php -v` warning | `extension_loaded` | engine active (`enable_cli=1`) |
| --- | --- | --- | --- | --- |
| 8.3.15 | block fires (`opcache.so`)           | none | true | true |
| 8.4.22 | parent `docker-php-ext-opcache.ini`  | none | true | true |
| 8.5.7  | static (block skipped)               | none | true | true |

OPcache stays enabled on every build, the double-load warning is gone, and `opcache.ini` still tunes it (it carries no `zend_extension` line).

Assisted-by: claude-code/claude-opus-4-8