### PR TITLE
fix(php8): restore OpenSSL support for ftp extension

### DIFF
--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -45,7 +45,11 @@ RUN export XDEBUG_DEPS="linux-headers" && \
     docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include && \
     docker-php-ext-configure ldap && \
     export OPENSSL_LIBS="-L/usr -lssl -lcrypto -lz" && export OPENSSL_CFLAGS="-I/usr/include" && \
-    docker-php-ext-configure ftp --with-openssl-dir=/usr/include/ && \
+    if php -r 'exit(version_compare(PHP_VERSION, "8.4", "<") ? 0 : 1);'; then \
+        docker-php-ext-configure ftp --with-openssl-dir=/usr/include/; \
+    else \
+        docker-php-ext-configure ftp --with-ftp-ssl; \
+    fi && \
     docker-php-ext-install bcmath gd intl mbstring pcntl pdo pdo_mysql soap zip ldap ftp && \
     pecl install xdebug-${XDEBUG_VERSION} && \
     pecl install redis-${PHPREDIS_VERSION} && \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -44,7 +44,8 @@ RUN export XDEBUG_DEPS="linux-headers" && \
     apk add ${PHP_EXTRA_DEPS} ${PHPIZE_DEPS} ${XDEBUG_DEPS} gettext && \
     docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-webp=/usr/include && \
     docker-php-ext-configure ldap && \
-    docker-php-ext-configure ftp && \
+    export OPENSSL_LIBS="-L/usr -lssl -lcrypto -lz" && export OPENSSL_CFLAGS="-I/usr/include" && \
+    docker-php-ext-configure ftp --with-openssl-dir=/usr/include/ && \
     docker-php-ext-install bcmath gd intl mbstring pcntl pdo pdo_mysql soap zip ldap ftp && \
     pecl install xdebug-${XDEBUG_VERSION} && \
     pecl install redis-${PHPREDIS_VERSION} && \


### PR DESCRIPTION
### **User description**
## What

Restore OpenSSL support for the `ftp` PHP extension in the 8.x images so `ftp_ssl_connect()` is built again.

## Why

The `ftp` extension is currently compiled without OpenSSL, so `ftp_ssl_connect()` is undefined at runtime while `ftp_connect()` still works. Any FTP-over-TLS consumer fatals (e.g. `league/flysystem-ftp` with `ssl => true`: `Call to undefined function League\Flysystem\Ftp\ftp_ssl_connect()`).

This is a regression introduced by `7669dc42c` ("refactor(php8): consolidate 8.x images into a single folder"). Consolidating the per-version Dockerfiles into the shared `8/Dockerfile` dropped the OpenSSL wiring on the ftp configure step. `openssl-dev` is still installed, but without `--with-openssl-dir` the extension is configured without SSL.

## How

Re-add the OpenSSL env exports and `--with-openssl-dir` flag that the old `8.3/Dockerfile` had, before `docker-php-ext-install`.

## Verification

After rebuild:

```console
$ php -r "var_dump(function_exists('ftp_ssl_connect'));"
bool(true)
```

Affects all 8.x tags built from the shared `8/Dockerfile`.

Refs: #92


___

### **PR Type**
Bug fix


___

### **Description**
- Restore OpenSSL support for `ftp` PHP extension in 8.x images

- Re-add `--with-openssl-dir` flag to `docker-php-ext-configure ftp`

- Export `OPENSSL_LIBS` and `OPENSSL_CFLAGS` env vars before configure step

- Fixes `ftp_ssl_connect()` being undefined at runtime (regression from 8.x consolidation)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["8/Dockerfile RUN block"] -- "previously missing OpenSSL flags" --> B["ftp ext compiled without SSL"]
  B -- "caused" --> C["ftp_ssl_connect() undefined"]
  A -- "restored OPENSSL_LIBS & OPENSSL_CFLAGS exports" --> D["docker-php-ext-configure ftp --with-openssl-dir=/usr/include/"]
  D -- "ftp ext compiled with SSL" --> E["ftp_ssl_connect() available"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Restore OpenSSL configure flags for ftp PHP extension</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

8/Dockerfile

<ul><li>Replaced bare <code>docker-php-ext-configure ftp</code> with OpenSSL-aware <br>configuration<br> <li> Added <code>export OPENSSL_LIBS="-L/usr -lssl -lcrypto -lz"</code> and <code>export </code><br><code>OPENSSL_CFLAGS="-I/usr/include"</code> before the ftp configure step<br> <li> Added <code>--with-openssl-dir=/usr/include/</code> flag to <br><code>docker-php-ext-configure ftp</code><br> <li> Restores <code>ftp_ssl_connect()</code> availability for all 8.x image tags</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-php-base-image/pull/93/files#diff-b8b7d5c56c7cbedaef691cd107a4fbd1ccc5d436947ee1de17ad7244df1083ce">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

